### PR TITLE
Fix dingtalk identity provider compilation error

### DIFF
--- a/src/main/java/org/keycloak/social/DingTalkIdentityProvider.java
+++ b/src/main/java/org/keycloak/social/DingTalkIdentityProvider.java
@@ -79,7 +79,6 @@ public class DingTalkIdentityProvider extends AbstractOAuth2IdentityProvider imp
         user.setUserAttribute("stateCode", getJsonProperty(profile, "stateCode"));
         user.setUserAttribute("unionId", getJsonProperty(profile, "unionId"));
         user.setUserAttribute("openId", getJsonProperty(profile, "openId"));
-        user.setIdpConfig(getConfig());
         user.setIdp(this);
 
         AbstractJsonUserAttributeMapper.storeUserProfileForMapper(user, profile, getConfig().getAlias());


### PR DESCRIPTION
Remove redundant `setIdpConfig` call from `BrokeredIdentityContext` to fix compilation with Keycloak 26.3.4.

The `setIdpConfig` method was removed from `BrokeredIdentityContext` in Keycloak 26.3.4. The configuration is now passed directly to the constructor, making the separate `setIdpConfig` call redundant and causing a compilation error.

---
<a href="https://cursor.com/background-agent?bcId=bc-f9a0099f-9b96-4d73-8faa-57906c5d75c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f9a0099f-9b96-4d73-8faa-57906c5d75c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

